### PR TITLE
Fix server register error at transactionsRoutes

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -4,7 +4,9 @@ import { transactionsRoutes } from './routes/transactions'
 
 const app = fastify()
 
-app.register(transactionsRoutes)
+app.register(transactionsRoutes, {
+  prefix: '/transactions',
+})
 
 app
   .listen({


### PR DESCRIPTION
Add the...

prefix: '/transactions',

To the transactionsRoutes so it can find the correct path.